### PR TITLE
[feat] 로그인 시 db에 회원정보 조회 후 없다면 db 저장

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,12 +11,16 @@
   "dependencies": {
     "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.50.0",
+    "mysql": "^2.18.1",
+    "mysql2": "^3.14.1",
     "next": "15.3.3",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@types/mysql": "^2",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
-
 import { createClientForServer } from "@/utils/supabase/server";
+import { findUserById } from "../../lib/userRepo";
+import { v4 as uuidv4 } from "uuid";
 
 export async function GET(request: NextRequest) {
   const { searchParams, origin } = new URL(request.url);
@@ -10,15 +11,42 @@ export async function GET(request: NextRequest) {
   if (code) {
     const supabase = await createClientForServer();
     const { error } = await supabase.auth.exchangeCodeForSession(code); // code 값을 넣으면 Auth 액세스 토큰을 리턴
+
     if (!error) {
-      const forwardedHost = request.headers.get("x-forwarded-host");
-      const isLocalEnv = process.env.NODE_ENV === "development";
-      if (isLocalEnv) {
-        return NextResponse.redirect(`${origin}${next}`);
-      } else if (forwardedHost) {
-        return NextResponse.redirect(`https://${forwardedHost}${next}`);
-      } else {
-        return NextResponse.redirect(`${origin}${next}`);
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (user) {
+        const { id, user_metadata, email, app_metadata } = user;
+
+        const userData = await findUserById(id);
+        console.log("👤 유저 테이블에 존재하는가?", userData);
+
+        if (!userData) {
+          // 유저가 테이블에 없으면 새로 insert
+          await supabase.from("users").insert({
+            id,
+            email,
+            nickname: email?.split("@")[0],
+            name: user_metadata.full_name ?? "",
+            profile_image_url: user_metadata.avatar_url ?? "",
+            provider: app_metadata.provider ?? "google",
+          });
+          console.log("✅ 유저 새로 등록됨");
+        } else {
+          console.log("🔄 이미 등록된 유저");
+        }
+
+        const forwardedHost = request.headers.get("x-forwarded-host");
+        const isLocalEnv = process.env.NODE_ENV === "development";
+        if (isLocalEnv) {
+          return NextResponse.redirect(`${origin}${next}`);
+        } else if (forwardedHost) {
+          return NextResponse.redirect(`https://${forwardedHost}${next}`);
+        } else {
+          return NextResponse.redirect(`${origin}${next}`);
+        }
       }
     }
   }

--- a/src/app/lib/userRepo.ts
+++ b/src/app/lib/userRepo.ts
@@ -1,0 +1,19 @@
+// lib/userRepo.ts
+import type { User } from "../types/user";
+import { createClientForServer } from "@/utils/supabase/server";
+
+export async function findUserById(id: string) {
+  const supabase = await createClientForServer();
+  const { data, error } = await supabase
+    .from("users")
+    .select("*")
+    .eq("id", id)
+    .single();
+
+  if (error && error.code !== "PGRST116") {
+    // PGRST116 = no rows returned (safe to return null)
+    console.error("❗ Supabase error:", error);
+    throw error;
+  }
+  return data ?? null;
+}

--- a/src/app/types/user.ts
+++ b/src/app/types/user.ts
@@ -1,0 +1,10 @@
+export type User = {
+  id: string; // UUID
+  email: string;
+  name: string | null;
+  profile_image_url: string | null;
+  provider: string;
+  created_at: string;
+  updated_at: string;
+  is_deleted: boolean;
+};


### PR DESCRIPTION
## Supabase DB 연동 및 회원 정보 조회

### PR 생성 날짜
* 2025/06/25

## 작업 내용
- 구글 로그인 성공 후 Supabase Auth의 user 정보를 받아옴
- 받은 user.id로 Supabase `users` 테이블에서 존재 여부 확인
- 존재하지 않으면 `users` 테이블에 새 유저 정보 삽입
  - email, name, profile_image_url, provider 등 저장
- Supabase RLS 및 정책 설정 완료

## 참고
- `lib/userRepo.ts`에서 유저 조회 함수 (`findUserById`) 구현
- 로그인 이후 리다이렉션 처리도 `/auth/callback/route.ts`에서 설정
